### PR TITLE
Fix incorrect value passed to match

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ export default function app (selector, routes = ['*']) {
       a.classList.contains('no-ajax')
     ) return
 
-    const [ path, route ] = match(a.pathname)
+    const [ path, route ] = match(a.href)
 
     if (route.ignore) return e
 


### PR DESCRIPTION
This fixes navigation on anchors that contain query parameters